### PR TITLE
docs: update installation instructions for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Alternatively, install Starship using any of the following package managers:
 | Alpine Linux 3.13+ | [Alpine Linux Packages] | `apk add starship`                                            |
 | Arch Linux         | [Arch Linux Community]  | `pacman -S starship`                                          |
 | CentOS 7+          | [Copr]                  | `dnf copr enable atim/starship` <br /> `dnf install starship` |
-| Fedora 31+         | [Fedora Packages]       | `dnf install starship`                                        |
+| Fedora 35+         | [Copr]                  | `dnf copr enable atim/starship` <br /> `dnf install starship` |
 | Gentoo             | [Gentoo Packages]       | `emerge app-shells/starship`                                  |
 | Manjaro            |                         | `pacman -S starship`                                          |
 | NixOS              | [nixpkgs]               | `nix-env -iA nixpkgs.starship`                                |
@@ -435,7 +435,6 @@ This project is [ISC](https://github.com/starship/starship/blob/master/LICENSE) 
 [conda-forge]: https://anaconda.org/conda-forge/starship
 [copr]: https://copr.fedorainfracloud.org/coprs/atim/starship
 [crates.io]: https://crates.io/crates/starship
-[fedora packages]: https://src.fedoraproject.org/rpms/rust-starship
 [freshports]: https://www.freshports.org/shells/starship
 [gentoo packages]: https://packages.gentoo.org/packages/app-shells/starship
 [linuxbrew]: https://formulae.brew.sh/formula/starship


### PR DESCRIPTION
#### Description
On Fedora install from the __atim/starship__ COPR repository.

#### Motivation and Context

The package was retired from the official Fedora repositories[^1].

[^1]: https://bugzilla.redhat.com/show_bug.cgi?id=2051601#c20

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
